### PR TITLE
Raise PAUSED_BY_NETWORK reason when there's connection

### DIFF
--- a/dtglib/src/main/java/com/kaltura/dtg/clear/DefaultDownloadService.java
+++ b/dtglib/src/main/java/com/kaltura/dtg/clear/DefaultDownloadService.java
@@ -744,7 +744,7 @@ public class DefaultDownloadService extends Service {
                         ConnectivityManager connManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
                         if (connManager != null) {
                             NetworkInfo networkInfo = connManager.getActiveNetworkInfo();
-                            if (networkInfo != null && (!networkInfo.isConnected() || !networkInfo.isAvailable())) {
+                            if (networkInfo == null || (!networkInfo.isConnected() || !networkInfo.isAvailable())) {
                                 if (item.getState() != DownloadState.PAUSED) {
                                     pauseDownload(item, DownloadStateReason.PAUSED_BY_NETWORK);
                                     break;


### PR DESCRIPTION
The old code was reporting a PAUSED_BY_ERROR reason when the `ConnectivityManager.getActiveNetworkInfo()` returned null, now a PAUSE_BY_NETWORK error is thrown.
Ps: The DTG is throwing 2 exceptions. The first is still a PAUSED_BY_ERROR and the second is a PAUSED_BY_NETWORK but sometimes the second one is not being sent. This issue still need to be addressed to decrease the failure rate.